### PR TITLE
networkmanager: persistence

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,11 @@
     formatter = lib.genAttrs defaultSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
     nixosModules = rec {
       environment = import ./nixos-modules/environment/persistence.nix;
+      networkmanager = import ./nixos-modules/networkmanager/persistence.nix;
       default = {
         imports = [
           environment
+          networkmanager
         ];
       };
     };

--- a/nixos-modules/networkmanager/persistence.nix
+++ b/nixos-modules/networkmanager/persistence.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.networking.networkmanager;
+in {
+  options = with lib; {
+    networking.networkmanager.persistence = mkOption {
+      type = types.attrsOf types.raw;
+      default = {
+        transient.directories = ["/var/lib/NetworkManager"];
+        secret.directories = ["/etc/NetworkManager/system-connections"];
+      };
+      description = ''
+        Persist network manager settings, keys, and connections.
+      '';
+    };
+  };
+
+  config = let
+    persistence = builtins.intersectAttrs config.environment.automaticPersistence cfg.persistence;
+  in
+    lib.mkIf (cfg.enable && persistence != {}) {
+      environment.persistence =
+        lib.mkMerge
+        (lib.mapAttrsToList
+          (k: v: {${config.environment.automaticPersistence.${k}.path} = v;})
+          persistence);
+    };
+}


### PR DESCRIPTION
Retains `/etc/NetworkManager/system-connections` at the `secret` persistence level.
Also retains `/var/lib/NetworkManager` at the `transient` persistence level.