### PR TITLE
bluetooth: persistence

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,12 @@
   in {
     formatter = lib.genAttrs defaultSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
     nixosModules = rec {
+      bluetooth = import ./nixos-modules/bluetooth/persistence.nix;
       environment = import ./nixos-modules/environment/persistence.nix;
       networkmanager = import ./nixos-modules/networkmanager/persistence.nix;
       default = {
         imports = [
+          bluetooth
           environment
           networkmanager
         ];

--- a/nixos-modules/bluetooth/persistence.nix
+++ b/nixos-modules/bluetooth/persistence.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.hardware.bluetooth;
+in {
+  options = with lib; {
+    hardware.bluetooth.persistence = mkOption {
+      type = types.attrsOf types.raw;
+      default = {
+        normal.directories = ["/var/lib/bluetooth"];
+      };
+      description = ''
+        Persist bluetooth settings and caches (all adapters).
+        See https://github.com/pauloborges/bluez/blob/master/doc/settings-storage.txt for details.
+      '';
+    };
+  };
+
+  config = let
+    persistence = builtins.intersectAttrs config.environment.automaticPersistence cfg.persistence;
+  in
+    lib.mkIf (cfg.enable && persistence != {}) {
+      environment.persistence =
+        lib.mkMerge
+        (lib.mapAttrsToList
+          (k: v: {${config.environment.automaticPersistence.${k}.path} = v;})
+          persistence);
+    };
+}


### PR DESCRIPTION
Retains `/var/lib/bluetooth` in the `normal` persistence level