### PR TITLE
sound: persistence

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,13 @@
       bluetooth = import ./nixos-modules/bluetooth/persistence.nix;
       environment = import ./nixos-modules/environment/persistence.nix;
       networkmanager = import ./nixos-modules/networkmanager/persistence.nix;
+      sound = import ./nixos-modules/sound/persistence.nix;
       default = {
         imports = [
           bluetooth
           environment
           networkmanager
+          sound
         ];
       };
     };

--- a/nixos-modules/sound/persistence.nix
+++ b/nixos-modules/sound/persistence.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.sound;
+in {
+  options = with lib; {
+    sound.persistence = mkOption {
+      type = types.attrsOf types.raw;
+      default = {
+        transient.files = ["/var/lib/alsa/asound.state"];
+      };
+      description = ''
+        Persist audio volume settings, managed via a combination of alsactl and systemd.
+      '';
+    };
+  };
+
+  config = let
+    persistence = builtins.intersectAttrs config.environment.automaticPersistence cfg.persistence;
+  in
+    lib.mkIf (cfg.enable && persistence != {}) {
+      environment.persistence =
+        lib.mkMerge
+        (lib.mapAttrsToList
+          (k: v: {${config.environment.automaticPersistence.${k}.path} = v;})
+          persistence);
+    };
+}


### PR DESCRIPTION
Retains `/var/lib/alsa/asound.state` in the `normal` persistence level.