### PR TITLE
ssh: persistence

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,12 +27,14 @@
       environment = import ./nixos-modules/environment/persistence.nix;
       networkmanager = import ./nixos-modules/networkmanager/persistence.nix;
       sound = import ./nixos-modules/sound/persistence.nix;
+      ssh = import ./nixos-modules/ssh/persistence.nix;
       default = {
         imports = [
           bluetooth
           environment
           networkmanager
           sound
+          ssh
         ];
       };
     };

--- a/nixos-modules/ssh/persistence.nix
+++ b/nixos-modules/ssh/persistence.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.programs.ssh;
+in {
+  options = with lib; {
+    programs.ssh.persistence = mkOption {
+      type = types.attrsOf types.raw;
+      default = {
+        secret.files = [
+          "/etc/ssh/ssh_host_ed25519_key"
+          "/etc/ssh/ssh_host_ed25519_key.pub"
+          "/etc/ssh/ssh_host_rsa_key"
+          "/etc/ssh/ssh_host_rsa_key.pub"
+        ];
+      };
+      description = ''
+        Persist SSH host keys.
+      '';
+    };
+  };
+
+  config = let
+    persistence = builtins.intersectAttrs config.environment.automaticPersistence cfg.persistence;
+  in
+    lib.mkIf (persistence != {}) {
+      environment.persistence =
+        lib.mkMerge
+        (lib.mapAttrsToList
+          (k: v: {${config.environment.automaticPersistence.${k}.path} = v;})
+          persistence);
+    };
+}


### PR DESCRIPTION
Retains host keys (both private and public) in `/etc/ssh` in `secret` persistence levels.

It's somewhat debatable whether `.pub` keys ought to be stored only at a lower persistence level. I've opted to classify public keys as confidential. My reasoning is:

* Generating public keys from the private key seems a little bit impractical to me. However if someone has a use case I'd be happy to revisit.
* Public keys are confidential in the sense that they could be used to identify you.

Note that this doesn't get turned on by an `enable` option like most other programs because `programs.ssh` has no such option. (It is always enabled)

Finally, keep in mind that `/etc/ssh` contains symlinks to nixos generated config in `/etc/static` (ssh_config, known hosts, authorized keys, etc).
