### PR TITLE
users: persistence (mutableUsers)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
       sound = import ./nixos-modules/sound/persistence.nix;
       ssh = import ./nixos-modules/ssh/persistence.nix;
       tailscale = import ./nixos-modules/tailscale/persistence.nix;
+      users = import ./nixos-modules/users/persistence.nix;
       default = {
         imports = [
           bluetooth
@@ -37,6 +38,7 @@
           sound
           ssh
           tailscale
+          users
         ];
       };
     };

--- a/nixos-modules/users/persistence.nix
+++ b/nixos-modules/users/persistence.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.users;
+in {
+  options = with lib; {
+    users.persistence = mkOption {
+      type = types.attrsOf types.raw;
+      default = {
+        secret.files = [
+          # See the comments starting from https://github.com/NixOS/nixpkgs/issues/3192#issuecomment-753521052
+          # for more color on how /etc/passwd, /etc/shadow is updated by passwd
+          "/etc/passwd"
+          "/etc/shadow"
+        ];
+      };
+      description = ''
+        Persist user credentials if `users.mutableUsers` is enabled.
+
+        WARNING: to change a password with `passwd` you *must* use the `--root` argument.
+        For example: `passwd --root /persistent/etc myusername`
+      '';
+    };
+  };
+
+  config = let
+    persistence = builtins.intersectAttrs config.environment.automaticPersistence cfg.persistence;
+  in
+    lib.mkIf (cfg.mutableUsers && persistence != {}) {
+      environment.persistence =
+        lib.mkMerge
+        (lib.mapAttrsToList
+          (k: v: {${config.environment.automaticPersistence.${k}.path} = v;})
+          persistence);
+    };
+}


### PR DESCRIPTION
Persists user credentials.

Take note of the issue with using `passwd` which is explained in this thread https://github.com/NixOS/nixpkgs/issues/3192

It appears that a solution is to use `passwd` with `--root` to chroot into the correct directory. (this is mentioned in the `description` for this option).